### PR TITLE
1.189.0

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -59,15 +59,15 @@ The following table provides version and version-support information about Insta
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>1.187.0</td>
+        <td>1.189.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>September 29, 2020</td>
+        <td>October 23, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>1.187.0</td>
+        <td>1.189.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -14,6 +14,15 @@ When you release a new version, add new release notes to this file, keeping the 
 
 These are release notes for Instana Microservices Application Monitoring for VMware Tanzu.
 
+##<a id="v1.189.0"></a> v1.189.0
+
+**Release Date:** October 23, 2020
+
+Improvements:
+
+* Latest and greatest Instana agent
+* Failure to delete the `instana-agent` namespace upon tile removal will not break rollouts, including smoke tests.
+
 ##<a id="v1.187.0"></a> v1.187.0
 
 **Release Date:** September 29, 2020


### PR DESCRIPTION
Improvements:

* Latest and greatest Instana agent
* Failure to delete the `instana-agent` namespace upon tile removal will not break rollouts, including smoke tests